### PR TITLE
Replace IsV# functions with use of go-version pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-errors/errors v1.0.1
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
 	github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4
-	github.com/hashicorp/go-version v1.2.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/magiconair/properties v1.8.1
 	github.com/martinlindhe/base36 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pkg/extractor/v6/extracts.go
+++ b/pkg/extractor/v6/extracts.go
@@ -999,6 +999,9 @@ func extractPreferencesFromDoc(doc *goquery.Document) ogame.Preferences {
 		PreserveSystemOnPlanetChange:       extractPreserveSystemOnPlanetChangeFromDoc(doc),
 		DiscoveryWarningEnabled:            extractDiscoveryWarningEnabledFromDoc(doc),
 		UrlaubsModus:                       extractUrlaubsModus(doc),
+		PlayerIntroductionIsVeteran:        extractPlayerIntroductionIsVeteran(doc),
+		PlayerIntroductionHideHighlights:   extractPlayerIntroductionHideHighlights(doc),
+		PlayerIntroductionHidePanel:        extractPlayerIntroductionHidePanel(doc),
 	}
 	if prefs.MobileVersion {
 		prefs.Notifications.BuildList = extractNotifBuildListFromDoc(doc)
@@ -1285,6 +1288,21 @@ func extractMobileVersionFromDoc(doc *goquery.Document) bool {
 
 func extractUrlaubsModus(doc *goquery.Document) bool {
 	_, exists := doc.Find("input[name=urlaubs_modus]").Attr("checked")
+	return exists
+}
+
+func extractPlayerIntroductionIsVeteran(doc *goquery.Document) bool {
+	_, exists := doc.Find("input[name=playerIntroductionIsVeteran]").Attr("checked")
+	return exists
+}
+
+func extractPlayerIntroductionHideHighlights(doc *goquery.Document) bool {
+	_, exists := doc.Find("input[name=playerIntroductionHideHighlights]").Attr("checked")
+	return exists
+}
+
+func extractPlayerIntroductionHidePanel(doc *goquery.Document) bool {
+	_, exists := doc.Find("input[name=playerIntroductionHidePanel]").Attr("checked")
 	return exists
 }
 

--- a/pkg/ogame/ogame.go
+++ b/pkg/ogame/ogame.go
@@ -241,6 +241,9 @@ type Preferences struct {
 	PreserveSystemOnPlanetChange       bool
 	DiscoveryWarningEnabled            bool
 	UrlaubsModus                       bool // Vacation mode
+	PlayerIntroductionIsVeteran        bool
+	PlayerIntroductionHideHighlights   bool
+	PlayerIntroductionHidePanel        bool
 
 	// Mobile only
 	Notifications struct {

--- a/pkg/wrapper/ogame.go
+++ b/pkg/wrapper/ogame.go
@@ -1784,7 +1784,15 @@ func (b *OGame) setPreferences(p ogame.Preferences) error {
 		"selectedTab": {"0"},
 		"token":       {token},
 	}
-
+	if p.PlayerIntroductionIsVeteran {
+		payload.Set("playerIntroductionIsVeteran", "on")
+	}
+	if p.PlayerIntroductionHideHighlights {
+		payload.Set("playerIntroductionHideHighlights", "on")
+	}
+	if p.PlayerIntroductionHidePanel {
+		payload.Set("playerIntroductionHidePanel", "on")
+	}
 	if p.ShowOldDropDowns {
 		payload.Set("showOldDropDowns", "on")
 	}

--- a/pkg/wrapper/ogame.go
+++ b/pkg/wrapper/ogame.go
@@ -910,7 +910,10 @@ func (b *OGame) SetProxy(proxyAddress, username, password, proxyType string, log
 }
 
 func (b *OGame) connectChat(chatRetry *exponentialBackoff.ExponentialBackoff, host, port string) {
-	if b.IsV8() || b.IsV9() || b.IsV10() {
+	minVersionV8, _ := version.NewVersion("8")
+	currentVersion, _ := version.NewVersion(b.serverData.Version)
+
+	if currentVersion.GreaterThanOrEqual(minVersionV8) { //if b.IsV8() || b.IsV9() || b.IsV10() {
 		b.connectChatV8(chatRetry, host, port)
 	} else {
 		b.connectChatV7(chatRetry, host, port)
@@ -2913,7 +2916,10 @@ func (b *OGame) galaxyInfos(galaxy, system int64, opts ...Option) (ogame.SystemI
 		"system": {utils.FI64(system)},
 	}
 	var vals url.Values
-	if b.IsV10() {
+	v10, _ := version.NewVersion("10")
+	currentVersion, _ := version.NewVersion(b.serverData.Version)
+
+	if currentVersion.GreaterThanOrEqual(v10) { // b.IsV10() {
 		vals = url.Values{"page": {"ingame"}, "component": {"galaxy"}, "action": {"fetchGalaxyContent"}, "ajax": {"1"}, "asJson": {"1"}}
 	} else {
 		vals = url.Values{"page": {"ingame"}, "component": {"galaxyContent"}, "ajax": {"1"}}
@@ -3188,8 +3194,10 @@ func (b *OGame) build(celestialID ogame.CelestialID, id ogame.ID, nbr int64) err
 	if err != nil {
 		return err
 	}
+	v104, _ := version.NewVersion("10.4")
+	currentVersion, _ := version.NewVersion(b.serverData.Version)
 
-	if b.IsV104() {
+	if currentVersion.GreaterThanOrEqual(v104) { // if b.IsV104() {
 		vals := url.Values{
 			"page":      {"componentOnly"},
 			"component": {"buildlistactions"},
@@ -3616,7 +3624,10 @@ func (b *OGame) sendFleet(celestialID ogame.CelestialID, ships []ogame.Quantifia
 	}
 
 	tokenM := regexp.MustCompile(`var fleetSendingToken = "([^"]+)";`).FindSubmatch(pageHTML)
-	if b.IsV8() || b.IsV9() || b.IsV10() {
+	v8, _ := version.NewVersion("8")
+	currentVersion, _ := version.NewVersion(b.serverData.Version)
+
+	if currentVersion.GreaterThanOrEqual(v8) { //b.IsV8() || b.IsV9() || b.IsV10() {
 		tokenM = regexp.MustCompile(`var token = "([^"]+)";`).FindSubmatch(pageHTML)
 	}
 	if len(tokenM) != 2 {
@@ -3688,7 +3699,7 @@ func (b *OGame) sendFleet(celestialID ogame.CelestialID, ships []ogame.Quantifia
 	newResources.Deuterium = utils.MaxInt(newResources.Deuterium, 0)
 
 	// Page 3 : select coord, mission, speed
-	if b.IsV8() || b.IsV9() || b.IsV10() {
+	if currentVersion.GreaterThanOrEqual(v8) { //b.IsV8() || b.IsV9() || b.IsV10() {
 		payload.Set("token", checkRes.NewAjaxToken)
 	}
 	payload.Set("speed", strconv.FormatInt(int64(speed), 10))
@@ -3807,7 +3818,10 @@ func (b *OGame) sendDiscovery(celestialID ogame.CelestialID, where ogame.Coordin
 	payload := url.Values{}
 
 	tokenM := regexp.MustCompile(`var fleetSendingToken = "([^"]+)";`).FindSubmatch(pageHTML)
-	if b.IsV8() || b.IsV9() || b.IsV10() {
+	v8, _ := version.NewVersion("8")
+	currentVersion, _ := version.NewVersion(b.serverData.Version)
+
+	if currentVersion.GreaterThanOrEqual(v8) { //b.IsV8() || b.IsV9() || b.IsV10() {
 		tokenM = regexp.MustCompile(`var token = "([^"]+)";`).FindSubmatch(pageHTML)
 	}
 	if len(tokenM) != 2 {


### PR DESCRIPTION
Example:

```
import(
   "github.com/hashicorp/go-version"
)

v10, _ := version.NewVersion("10")
currentVersion, _ := version.NewVersion(b.serverData.Version)

if currentVersion.GreaterThanOrEqual(v10) { // replaced b.IsV10() {
...do something
}
```